### PR TITLE
Add missing object property override

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -445,6 +445,7 @@ function booking_add_instance($booking) {
 
     // To avoid errors.
     $booking->bookingpolicy = $booking->bookingpolicy['text'] ?? '';
+    $booking->notificationtext = $booking->notificationtext['text'] ?? '';
     // Insert answer options from mod_form.
     $booking->id = $DB->insert_record("booking", $booking);
 


### PR DESCRIPTION
This MR fixes `mysqli::real_escape_string()` error.

```
2) mod_booking\booking_option_test::test_delete_responses_activitycompletion
mysqli::real_escape_string() expects parameter 1 to be string, array given

/var/www/site/lib/dml/mysqli_native_moodle_database.php:1154
/var/www/site/lib/dml/mysqli_native_moodle_database.php:1366
/var/www/site/lib/dml/mysqli_native_moodle_database.php:1417
/var/www/site/mod/booking/lib.php:449
/var/www/site/course/modlib.php:137
/var/www/site/lib/testing/generator/module_generator.php:278
/var/www/site/mod/booking/tests/generator/lib.php:72
/var/www/site/lib/testing/generator/data_generator.php:503
/var/www/site/mod/booking/tests/booking_option_test.php:76
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80
phpvfscomposer:///var/www/site/vendor/phpunit/phpunit/phpunit:97
```